### PR TITLE
Replace websocket-client with ws4py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-websocket-client
+ws4py

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(
     description="Python Wrapper for the Google Chrome Remote Debugging Protocol",
     author='Chris Seymour',
     packages=find_packages(),
-    install_requires=['requests', 'websocket-client']
+    install_requires=['requests', 'ws4py']
 )


### PR DESCRIPTION
This PR is more of a heads-up to let you know that I've found `ws4py` much more robust than `websocket-client`.  For example, the intermittent errors I sometimes found, e.g., in #3, all disappeared with `ws4py`.  If you're curious, I'm using this change from [my fork](https://github.com/cjrh/chromote/tree/switch-to-ws4py), here: https://github.com/cjrh/google-images-downloader.

The commit message follows:

I found very strange intermittent errors with websocket-client.
Sometimes the result of an `execute` command would not get returned.
I don't know why exactly, but I experimented with changing websocket
functionality to use ws4py, which is a much higher-quality library.

In it's most basic configuration, ws4py depends only on stdlib.
