### PR TITLE
docs: fix simple typo, demostrating -> demonstrating

### DIFF
--- a/example/run.py
+++ b/example/run.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Example script demostrating the use of Chromote to
+Example script demonstrating the use of Chromote to
 update a remote browser periodically from a list of sites
 """
 


### PR DESCRIPTION
There is a small typo in example/run.py.

Should read `demonstrating` rather than `demostrating`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md